### PR TITLE
Update rtree.py

### DIFF
--- a/pyrtree/rtree.py
+++ b/pyrtree/rtree.py
@@ -247,7 +247,7 @@ class _NodeCursor(object):
         memo = {}
 
         clusterings = [ k_means_cluster(self.root,k,s_children) for k in range(2,MAX_KMEANS) ]
-        score,bestcluster = max( [ (silhouette_coeff(c,memo),c) for c in clusterings ])
+        score,bestcluster = max( [ (silhouette_coeff(c,memo),c) for c in clusterings ], key=lambda x:x[0])
 
         nodes = [ _NodeCursor.create_with_children(c,self.root) for c in bestcluster if len(c) > 0]
 


### PR DESCRIPTION
Fixes '>' not supported between instances of '_NodeCursor' and '_NodeCursor', which happens when there are identical silhouette coefficients, as the max method will then try to sort by the nodes, but there is no compare method defined on the nodes. This fix will just select one of the best silhouette coefficients